### PR TITLE
FortiManager: support locking the global workspace

### DIFF
--- a/ftntlib/fmg_jsonapi.py
+++ b/ftntlib/fmg_jsonapi.py
@@ -561,10 +561,16 @@ class FortiManagerJSON (object):
         return response['data']['workspace-mode']
 
     def _workspace (self, adom, action,pkgpath=False):
-        if pkgpath:
-            url = 'pm/config/adom/'+str(adom)+'/_workspace/'+str(action)+'/'+str(pkgpath)
+        if adom == 'global':
+            base_url = 'pm/config/global'
         else:
-            url = 'pm/config/adom/'+str(adom)+'/_workspace/'+str(action)
+            base_url = 'pm/config/adom/' + str(adom)
+
+        if pkgpath:
+            url = base_url + '/_workspace/'+str(action)+'/'+str(pkgpath)
+        else:
+            url = base_url + '/_workspace/'+str(action)
+
         status, response = self._do('exec',url)
         return status, response
          


### PR DESCRIPTION
Support locking the global database by setting the adom parameter to =global=.

I'm not  a Forti Expert, but I afaik the global database is different than a regular ADOM. Maybe it makes more sense to rename the parameter in order to support this use case. What do you think?

Regards,
Alex