### PR TITLE
Replace suds-jurko by suds-community

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ from setuptools import setup
 
 setup(
       name='ftntlib',
-      version='0.4.0.dev20',
+      version='0.4.0.dev21',
       description='Python modules to interact with Fortinet products',
-      install_requires=['requests','suds-jurko','lxml'],
+      install_requires=['requests','suds-community','lxml'],
       author='Original: Ashton Turpin, Maintainer: Jean-Pierre Forcioli, Contributors: Jeremy Parente',
       author_email='jpforcioli@fortinet.com, jparente@fortinet.com',
       url='https://fndn.fortinet.net',


### PR DESCRIPTION
ftntlib build breaks with the following error :

```
    ERROR: Command errored out with exit status 1:
     command: /venv/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-jlypgrk4/suds-jurko_660395d9c75f4258bbf006501bbf458a/setup.py'"'"'; __file__='"'"'/tmp/pip-install-jlypgrk4/suds-jurko_660395d9c75f4258bbf006501bbf458a/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-313d7bvh
         cwd: /tmp/pip-install-jlypgrk4/suds-jurko_660395d9c75f4258bbf006501bbf458a/
    Complete output (1 lines):
    error in suds-jurko setup command: use_2to3 is invalid.
    ----------------------------------------
```

suds-jurko is not maintained anymore and uses some features which doesn't exist anymore in setuptools > 58

More details about this issue :
https://github.com/AnalogJ/lexicon/issues/962

suds-community is an active fork of suds-jurko. 